### PR TITLE
Fix ToString usage for Int

### DIFF
--- a/src/ttmath.nim
+++ b/src/ttmath.nim
@@ -63,7 +63,7 @@ proc `mod`*(a, b: TTInt): TTInt =
   var tmp = a
   tmp.inplaceDiv(b, result)
 
-proc ToString(a: TTInt, s: stdString) {.importcpp, header: TTMATH_HEADER.}
+proc ToString(a: TTInt): stdString {.importcpp, header: TTMATH_HEADER.}
 
 proc initInt[T](a: int64): T {.importcpp: "'0((int)#)".}
 proc initUInt[T](a: uint64): T {.importcpp: "'0((int)#)".}
@@ -109,8 +109,7 @@ proc getInt*(a: Int): int {.importcpp: "ToInt", header: TTMATH_HEADER.}
 proc getUInt*(a: UInt): uint64 {.importcpp: "ToUInt", header: TTMATH_HEADER.}
 
 proc `$`*(a: Int or UInt): string =
-  var tmp: stdString
-  a.ToString(tmp)
+  let tmp = a.ToString()
   var tmps: cstring
   {.emit: """
   `tmps` = const_cast<char*>(`tmp`.c_str());


### PR DESCRIPTION
For some reason I was getting a segfault otherwise (in `result.clear` in `ttmathuint.h`)